### PR TITLE
Use `embed` for PowerShell

### DIFF
--- a/Containerfile (backtick escape).sublime-syntax
+++ b/Containerfile (backtick escape).sublime-syntax
@@ -12,8 +12,8 @@ variables:
 
 contexts:
   embedded_shell:
-    - meta_scope: source.powershell.embedded.containerfile
-    - include: line-continuation
-    - match: $
-      pop: true
-    - include: scope:source.powershell
+    - match: (?=\S)
+      embed: scope:source.powershell
+      escape: (?<!`)$\n
+    - match: ^(?!.*`$)
+      pop: 1


### PR DESCRIPTION
PowerShell syntax v5 is going to make the `include` approach less successful.

If DeathAxe makes a PR with a custom `extend`ed PowerShell, obviously take his change instead.
See https://github.com/SublimeText/PowerShell/issues/213