### PR TITLE
Use single `source` scope for backtick mode

### DIFF
--- a/Containerfile.sublime-syntax
+++ b/Containerfile.sublime-syntax
@@ -18,6 +18,9 @@ variables:
 
 contexts:
   main:
+    - include: statements
+
+  statements:
     - include: parser-directives
     - include: comments
     - match: (?i)^\s*(?=ARG|FROM)\b
@@ -30,7 +33,7 @@ contexts:
       captures:
         1: comment.line.containerfile meta.annotation.containerfile punctuation.definition.annotation.containerfile
       set:
-        - scope:source.containerfile.backtick
+        - scope:source.containerfile.backtick#statements
         - parser-directive-body
     - match: '^\s*(#)(?=\s*\w+\s*=)'
       captures:

--- a/syntax_test_WindowsDockerfile.Dockerfile
+++ b/syntax_test_WindowsDockerfile.Dockerfile
@@ -10,6 +10,8 @@
 #The escape directive sets the character used to escape characters in a Dockerfile. If not specified, the default escape character is \.
 #The escape character is used both to escape characters in a line, and to escape a newline. This allows a Dockerfile instruction to span multiple lines. Note that regardless of whether the escape parser directive is included in a Dockerfile, escaping is not performed in a RUN command, except at the end of a line.
 
+# ^ - source source
+
 FROM microsoft/nanoserver
 COPY testfile.txt c:\
 RUN dir c:\


### PR DESCRIPTION
Don't double-up `source` scopes when backtick escape (PowerShell) mode is detected.

Fixes #11